### PR TITLE
Permit multiple Webview instances

### DIFF
--- a/fltk-webview-sys/webview/webview.h
+++ b/fltk-webview-sys/webview/webview.h
@@ -22,6 +22,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+#include <string>
+
 #ifndef WEBVIEW_H
 #define WEBVIEW_H
 
@@ -715,6 +718,12 @@ inline id operator"" _str(const char *s, std::size_t) {
   return objc::msg_send<id>("NSString"_cls, "stringWithUTF8String:"_sel, s);
 }
 
+inline std::string unique_name(std::string base) {
+  static int name_counter = 0;
+  base += std::to_string(name_counter++);
+  return base;
+}
+
 class cocoa_wkwebview_engine {
 public:
   cocoa_wkwebview_engine(bool debug, void *window)
@@ -827,7 +836,7 @@ private:
     // default name in projects created with Xcode, and using the same name
     // causes objc_registerClassPair to crash.
     auto cls = objc_allocateClassPair((Class) "NSResponder"_cls,
-                                      "WebviewAppDelegate", 0);
+                                      unique_name("WebviewAppDelegate").c_str(), 0);
     class_addProtocol(cls, objc_getProtocol("NSTouchBarProvider"));
     class_addMethod(cls, "applicationShouldTerminateAfterLastWindowClosed:"_sel,
                     (IMP)(+[](id, SEL, id) -> BOOL { return 1; }), "c@:@");
@@ -850,7 +859,7 @@ private:
   }
   id create_script_message_handler() {
     auto cls = objc_allocateClassPair((Class) "NSResponder"_cls,
-                                      "WebkitScriptMessageHandler", 0);
+                                      unique_name("WebkitScriptMessageHandler").c_str(), 0);
     class_addProtocol(cls, objc_getProtocol("WKScriptMessageHandler"));
     class_addMethod(
         cls, "userContentController:didReceiveScriptMessage:"_sel,
@@ -868,7 +877,7 @@ private:
   }
   static id create_webkit_ui_delegate() {
     auto cls =
-        objc_allocateClassPair((Class) "NSObject"_cls, "WebkitUIDelegate", 0);
+        objc_allocateClassPair((Class) "NSObject"_cls, unique_name("WebkitUIDelegate").c_str(), 0);
     class_addProtocol(cls, objc_getProtocol("WKUIDelegate"));
     class_addMethod(
         cls,


### PR DESCRIPTION
I really like `fltk-rs` and I'm hoping to be able to use it more. The one thing I ran into was creating multiple webview instances.

Only the first call to `objc_allocateClassPair` for a given name will succeed; subsequent calls return `nil` (`nullptr`), resulting in a segfault.

This is a low tech approach to getting around this restriction; there are undoubtedly more 'proper' ways of going about this but it works.

This change in its current form may or may not be acceptable to you; I'm using it locally and it works but you may have a preferred way of unblocking the same functionality. Either way, I'd be happy to help get the change in.

All the best 

Tosh